### PR TITLE
Fix default variable handling

### DIFF
--- a/src/yaml_prompt_manager.py
+++ b/src/yaml_prompt_manager.py
@@ -241,7 +241,8 @@ class YAMLPromptManager:
         
         final_variables = variables.copy()
         for var, default_value in defaults.items():
-            if var not in final_variables or not final_variables[var] or final_variables[var] == "None":
+            value = final_variables.get(var, None)
+            if var not in final_variables or value is None or value == "" or str(value).lower() == "none":
                 final_variables[var] = default_value
         
         return final_variables


### PR DESCRIPTION
## Summary
- avoid overwriting falsy values when applying defaults in YAMLPromptManager

## Testing
- `python -m py_compile src/yaml_prompt_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687524db8a04832ca76efd9c6f43c30a