### PR TITLE
Fix requirement filename typo

### DIFF
--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -27,7 +27,7 @@ AI_TC_Generator_v01/
 │       └── Ubuntu_Installation_Setup.txt
 ├── input/
 │   └── Reqifz_Files/
-│       └── sampe_requiremenr.reqif
+│       └── sample_requirement.reqif
 ├── output/
 │   └── TCD/
 │       └── README.md


### PR DESCRIPTION
## Summary
- correct `sampe_requiremenr.reqif` typo in the project structure documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875267f30c8832cb7811ad3c612457d